### PR TITLE
feat(android): Non-Consumable 아이템을 업그레이드, 다운그레이드 혹은 변경할 수 있는 기능 추가

### DIFF
--- a/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/MethodCallHandlerImpl.java
+++ b/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/MethodCallHandlerImpl.java
@@ -120,7 +120,10 @@ class MethodCallHandlerImpl
         break;
       case InAppPurchasePlugin.MethodNames.LAUNCH_BILLING_FLOW:
         launchBillingFlow(
-            (String) call.argument("sku"), (String) call.argument("accountId"), result);
+            (String) call.argument("sku"),
+            (String) call.argument("accountId"),
+            (String) call.argument("oldSku"),
+            (Integer) call.argument("replaceSkusProrationMode"), result);
         break;
       case InAppPurchasePlugin.MethodNames.QUERY_PURCHASES:
         queryPurchases((String) call.argument("skuType"), result);
@@ -189,7 +192,11 @@ class MethodCallHandlerImpl
   }
 
   private void launchBillingFlow(
-      String sku, @Nullable String accountId, MethodChannel.Result result) {
+      String sku,
+      @Nullable String accountId,
+      @Nullable String oldSku,
+      @Nullable Integer replaceSkusProrationMode,
+      MethodChannel.Result result) {
     if (billingClientError(result)) {
       return;
     }
@@ -214,10 +221,19 @@ class MethodCallHandlerImpl
     }
 
     BillingFlowParams.Builder paramsBuilder =
-        BillingFlowParams.newBuilder().setSkuDetails(skuDetails);
+        BillingFlowParams.newBuilder();
     if (accountId != null && !accountId.isEmpty()) {
       paramsBuilder.setAccountId(accountId);
     }
+    if (oldSku != null && replaceSkusProrationMode != null) {
+      paramsBuilder
+        .setOldSku(oldSku)
+        .setReplaceSkusProrationMode(replaceSkusProrationMode)
+        .setSkuDetails(skuDetails);
+    } else {
+      paramsBuilder.setSkuDetails(skuDetails);
+    }
+
     result.success(
         Translator.fromBillingResult(
             billingClient.launchBillingFlow(activity, paramsBuilder.build())));

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -156,6 +156,9 @@ class BillingClient {
   /// Do not pass in a cleartext [accountId], use your developer ID, or use the
   /// user's Google ID for this field.
   ///
+  /// The [oldSku] is specifies the SKU that the user is upgrading or downgrading from.
+  /// If allow users to upgrade, downgrade, or change their subscription, [oldSku] value must not be null.
+  ///
   /// The [replaceSkusProrationMode] is specifies the mode of proration during subscription upgrade/downgrade.
   /// If allow users to upgrade, downgrade, or change their subscription, [replaceSkusProrationMode] value must not be null.
   ///
@@ -178,8 +181,8 @@ class BillingClient {
   /// replaceSkusProrationMode](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setReplaceSkusProrationMode(int)).
   Future<BillingResultWrapper> launchBillingFlow(
       {@required String sku,
-      String accountId,
       String oldSku,
+      String accountId,
       ProrationMode replaceSkusProrationMode}) async {
     assert(sku != null);
     final Map<String, dynamic> arguments = <String, dynamic>{

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -156,6 +156,9 @@ class BillingClient {
   /// Do not pass in a cleartext [accountId], use your developer ID, or use the
   /// user's Google ID for this field.
   ///
+  /// The [replaceSkusProrationMode] is specifies the mode of proration during subscription upgrade/downgrade.
+  /// If allow users to upgrade, downgrade, or change their subscription, [replaceSkusProrationMode] value must not be null.
+  ///
   /// Calling this attemps to show the Google Play purchase UI. The user is free
   /// to complete the transaction there.
   ///
@@ -169,14 +172,22 @@ class BillingClient {
   /// [`BillingFlowParams`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams)
   /// instance by [setting the given
   /// skuDetails](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder.html#setskudetails)
-  /// and [the given
-  /// accountId](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder.html#setAccountId(java.lang.String)).
+  /// , [the given
+  /// accountId](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder.html#setAccountId(java.lang.String))
+  /// , [the given
+  /// replaceSkusProrationMode](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setReplaceSkusProrationMode(int)).
   Future<BillingResultWrapper> launchBillingFlow(
-      {@required String sku, String accountId}) async {
+      {@required String sku,
+      String accountId,
+      String oldSku,
+      ProrationMode replaceSkusProrationMode}) async {
     assert(sku != null);
     final Map<String, dynamic> arguments = <String, dynamic>{
       'sku': sku,
       'accountId': accountId,
+      'oldSku': oldSku,
+      'replaceSkusProrationMode':
+          ProrationModeConverter().toJson(replaceSkusProrationMode),
     };
     return BillingResultWrapper.fromJson(
         await channel.invokeMapMethod<String, dynamic>(
@@ -311,9 +322,9 @@ typedef void OnBillingServiceDisconnected();
 /// See the `BillingResponse` docs for more explanation of the different
 /// constants.
 enum BillingResponse {
-  // WARNING: Changes to this class need to be reflected in our generated code.
-  // Run `flutter packages pub run build_runner watch` to rebuild and watch for
-  // further changes.
+// WARNING: Changes to this class need to be reflected in our generated code.
+// Run `flutter packages pub run build_runner watch` to rebuild and watch for
+// further changes.
   /// The requested feature is not supported by Play Store on the current device.
   @JsonValue(-2)
   featureNotSupported,
@@ -365,9 +376,9 @@ enum BillingResponse {
 /// [`BillingClient.SkuType`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.SkuType)
 /// See the linked documentation for an explanation of the different constants.
 enum SkuType {
-  // WARNING: Changes to this class need to be reflected in our generated code.
-  // Run `flutter packages pub run build_runner watch` to rebuild and watch for
-  // further changes.
+// WARNING: Changes to this class need to be reflected in our generated code.
+// Run `flutter packages pub run build_runner watch` to rebuild and watch for
+// further changes.
 
   /// A one time product. Acquired in a single transaction.
   @JsonValue('inapp')
@@ -376,4 +387,40 @@ enum SkuType {
   /// A product requiring a recurring charge over time.
   @JsonValue('subs')
   subs,
+}
+
+/// Replace SKU ProrationMode.
+///
+/// Wraps
+/// [`BillingFlowParams.ProrationMode`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.ProrationMode)
+/// See the linked documentation for an explanation of the different constants.
+enum ProrationMode {
+// WARNING: Changes to this class need to be reflected in our generated code.
+// Run `flutter packages pub run build_runner watch` to rebuild and watch for
+// further changes.
+
+  /// Unknown subscription upgrade or downgrade policy.
+  @JsonValue(0)
+  unknownSubscriptionUpgradeDowngradePolicy,
+
+  /// Replacement takes effect immediately, and the remaining time will be prorated and credited to the user.
+  /// This is the current default behavior.
+  @JsonValue(1)
+  immediateWithTimeProration,
+
+  /// Replacement takes effect immediately, and the billing cycle remains the same.
+  /// The price for the remaining period will be charged.
+  /// This option is only available for subscription upgrade.
+  @JsonValue(2)
+  immediateAndChargeProratedPrice,
+
+  /// Replacement takes effect immediately, and the new price will be charged on next recurrence time.
+  /// The billing cycle stays the same.
+  @JsonValue(3)
+  immediateWithoutProration,
+
+  /// Replacement takes effect when the old plan expires,
+  /// and the new price will be charged at the same time.
+  @JsonValue(4)
+  deferred
 }

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/enum_converters.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/enum_converters.dart
@@ -46,6 +46,7 @@ class _SerializedEnums {
   BillingResponse response;
   SkuType type;
   PurchaseStateWrapper purchaseState;
+  ProrationMode prorationMode;
 }
 
 /// Serializer for [PurchaseStateWrapper].
@@ -81,4 +82,20 @@ class PurchaseStateConverter
 
     throw ArgumentError('$object isn\'t mapped to PurchaseStatus');
   }
+}
+
+/// Serializer for [ProrationMode].
+///
+/// Use these in `@JsonSerializable()` classes by annotating them with
+/// `@ProrationModeConverter()`.
+class ProrationModeConverter implements JsonConverter<ProrationMode, int> {
+  /// Default const constructor.
+  const ProrationModeConverter();
+
+  @override
+  ProrationMode fromJson(int json) => _$enumDecode<ProrationMode>(
+      _$ProrationModeEnumMap.cast<ProrationMode, dynamic>(), json);
+
+  @override
+  int toJson(ProrationMode object) => _$ProrationModeEnumMap[object];
 }

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/enum_converters.g.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/enum_converters.g.dart
@@ -11,7 +11,9 @@ _SerializedEnums _$_SerializedEnumsFromJson(Map json) {
     ..response = _$enumDecode(_$BillingResponseEnumMap, json['response'])
     ..type = _$enumDecode(_$SkuTypeEnumMap, json['type'])
     ..purchaseState =
-        _$enumDecode(_$PurchaseStateWrapperEnumMap, json['purchaseState']);
+        _$enumDecode(_$PurchaseStateWrapperEnumMap, json['purchaseState'])
+    ..prorationMode =
+        _$enumDecode(_$ProrationModeEnumMap, json['prorationMode']);
 }
 
 Map<String, dynamic> _$_SerializedEnumsToJson(_SerializedEnums instance) =>
@@ -19,6 +21,7 @@ Map<String, dynamic> _$_SerializedEnumsToJson(_SerializedEnums instance) =>
       'response': _$BillingResponseEnumMap[instance.response],
       'type': _$SkuTypeEnumMap[instance.type],
       'purchaseState': _$PurchaseStateWrapperEnumMap[instance.purchaseState],
+      'prorationMode': _$ProrationModeEnumMap[instance.prorationMode],
     };
 
 T _$enumDecode<T>(
@@ -65,4 +68,12 @@ const _$PurchaseStateWrapperEnumMap = {
   PurchaseStateWrapper.unspecified_state: 0,
   PurchaseStateWrapper.purchased: 1,
   PurchaseStateWrapper.pending: 2,
+};
+
+const _$ProrationModeEnumMap = {
+  ProrationMode.unknownSubscriptionUpgradeDowngradePolicy: 0,
+  ProrationMode.immediateWithTimeProration: 1,
+  ProrationMode.immediateAndChargeProratedPrice: 2,
+  ProrationMode.immediateWithoutProration: 3,
+  ProrationMode.deferred: 4,
 };

--- a/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
@@ -62,7 +62,7 @@ class GooglePlayConnection
         await billingClient.launchBillingFlow(
             sku: purchaseParam.productDetails.id,
             accountId: purchaseParam.applicationUserName,
-            oldSku: purchaseParam.oldProductDetails.id,
+            oldSku: purchaseParam.oldSku,
             replaceSkusProrationMode: purchaseParam.replaceProrationMode);
     return billingResultWrapper.responseCode == BillingResponse.ok;
   }

--- a/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
@@ -61,7 +61,9 @@ class GooglePlayConnection
     BillingResultWrapper billingResultWrapper =
         await billingClient.launchBillingFlow(
             sku: purchaseParam.productDetails.id,
-            accountId: purchaseParam.applicationUserName);
+            accountId: purchaseParam.applicationUserName,
+            oldSku: purchaseParam.oldProductDetails.id,
+            replaceSkusProrationMode: purchaseParam.replaceProrationMode);
     return billingResultWrapper.responseCode == BillingResponse.ok;
   }
 

--- a/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
@@ -91,7 +91,7 @@ class PurchaseParam {
     @required this.productDetails,
     this.applicationUserName,
     this.sandboxTesting,
-    this.oldProductDetails,
+    this.oldSku,
     this.replaceProrationMode,
   });
 
@@ -104,7 +104,7 @@ class PurchaseParam {
   ///
   /// The 'oldProductDetails' is only available on Android.
   /// Set it to not null for upgrading or downgrading subscription for current subscription. The default value is `null`.
-  final ProductDetails oldProductDetails;
+  final String oldSku;
 
   /// Specifies the mode of proration during subscription upgrade/downgrade.
   ///

--- a/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
@@ -87,15 +87,30 @@ enum PurchaseStatus {
 /// The parameter object for generating a purchase.
 class PurchaseParam {
   /// Creates a new purchase parameter object with the given data.
-  PurchaseParam(
-      {@required this.productDetails,
-      this.applicationUserName,
-      this.sandboxTesting});
+  PurchaseParam({
+    @required this.productDetails,
+    this.applicationUserName,
+    this.sandboxTesting,
+    this.oldProductDetails,
+    this.replaceProrationMode,
+  });
 
   /// The product to create payment for.
   ///
   /// It has to match one of the valid [ProductDetails] objects that you get from [ProductDetailsResponse] after calling [InAppPurchaseConnection.queryProductDetails].
   final ProductDetails productDetails;
+
+  /// Specifies the subscription that the user is upgrading or downgrading from.
+  ///
+  /// The 'oldProductDetails' is only available on Android.
+  /// Set it to not null for upgrading or downgrading subscription for current subscription. The default value is `null`.
+  final ProductDetails oldProductDetails;
+
+  /// Specifies the mode of proration during subscription upgrade/downgrade.
+  ///
+  /// The 'replaceProrationMode' is only available on Android.
+  /// This value will only be effective if the [oldProductDetails] is also set.
+  final ProrationMode replaceProrationMode;
 
   /// An opaque id for the user's account that's unique to your app. (Optional)
   ///
@@ -138,6 +153,7 @@ class PurchaseDetails {
 
   /// The status that this [PurchaseDetails] is currently on.
   PurchaseStatus get status => _status;
+
   set status(PurchaseStatus status) {
     if (_platform == _kPlatformIOS) {
       if (status == PurchaseStatus.purchased ||

--- a/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
@@ -100,16 +100,16 @@ class PurchaseParam {
   /// It has to match one of the valid [ProductDetails] objects that you get from [ProductDetailsResponse] after calling [InAppPurchaseConnection.queryProductDetails].
   final ProductDetails productDetails;
 
-  /// Specifies the subscription that the user is upgrading or downgrading from.
+  /// Specifies the subscription sku id that the user is upgrading or downgrading from.
   ///
-  /// The 'oldProductDetails' is only available on Android.
+  /// The 'oldSku' is only available on Android.
   /// Set it to not null for upgrading or downgrading subscription for current subscription. The default value is `null`.
   final String oldSku;
 
   /// Specifies the mode of proration during subscription upgrade/downgrade.
   ///
   /// The 'replaceProrationMode' is only available on Android.
-  /// This value will only be effective if the [oldProductDetails] is also set.
+  /// This value will only be effective if the [oldSku] is also set.
   final ProrationMode replaceProrationMode;
 
   /// An opaque id for the user's account that's unique to your app. (Optional)

--- a/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
@@ -104,12 +104,18 @@ class PurchaseParam {
   ///
   /// The 'oldSku' is only available on Android.
   /// Set it to not null for upgrading or downgrading subscription for current subscription. The default value is `null`.
+  ///
+  /// In iOS, this property is not used.
+  /// If you set up [productDetails] as you want to change, it will proceed automatically.
   final String oldSku;
 
   /// Specifies the mode of proration during subscription upgrade/downgrade.
   ///
   /// The 'replaceProrationMode' is only available on Android.
   /// This value will only be effective if the [oldSku] is also set.
+  ///
+  /// In iOS, this property is not used.
+  /// If you set up [productDetails] as you want to change, it will proceed automatically.
   final ProrationMode replaceProrationMode;
 
   /// An opaque id for the user's account that's unique to your app. (Optional)

--- a/packages/in_app_purchase/test/billing_client_wrappers/billing_client_wrapper_test.dart
+++ b/packages/in_app_purchase/test/billing_client_wrappers/billing_client_wrapper_test.dart
@@ -150,15 +150,22 @@ void main() {
       );
       final SkuDetailsWrapper skuDetails = dummySkuDetails;
       final String accountId = "hashedAccountId";
+      final String oldSku = "oldSku";
+      final ProrationMode replaceSkusProrationMode = ProrationMode.deferred;
 
       expect(
           await billingClient.launchBillingFlow(
-              sku: skuDetails.sku, accountId: accountId),
+              sku: skuDetails.sku,
+              accountId: accountId,
+              oldSku: oldSku,
+              replaceSkusProrationMode: replaceSkusProrationMode),
           equals(expectedBillingResult));
       Map<dynamic, dynamic> arguments =
           stubPlatform.previousCallMatching(launchMethodName).arguments;
       expect(arguments['sku'], equals(skuDetails.sku));
       expect(arguments['accountId'], equals(accountId));
+      expect(arguments['oldSku'], equals(oldSku));
+      expect(arguments['replaceSkusProrationMode'], equals(4));
     });
 
     test('handles null accountId', () async {
@@ -171,13 +178,46 @@ void main() {
         value: buildBillingResultMap(expectedBillingResult),
       );
       final SkuDetailsWrapper skuDetails = dummySkuDetails;
+      final String oldSku = "oldSku";
+      final ProrationMode replaceSkusProrationMode = ProrationMode.deferred;
 
-      expect(await billingClient.launchBillingFlow(sku: skuDetails.sku),
+      expect(
+          await billingClient.launchBillingFlow(
+              sku: skuDetails.sku,
+              oldSku: oldSku,
+              replaceSkusProrationMode: replaceSkusProrationMode),
           equals(expectedBillingResult));
       Map<dynamic, dynamic> arguments =
           stubPlatform.previousCallMatching(launchMethodName).arguments;
       expect(arguments['sku'], equals(skuDetails.sku));
       expect(arguments['accountId'], isNull);
+      expect(arguments['oldSku'], equals(oldSku));
+      expect(arguments['replaceSkusProrationMode'], equals(4));
+    });
+
+    test('handles null oldSku, replaceSkusProrationMode', () async {
+      const String debugMessage = 'dummy message';
+      final BillingResponse responseCode = BillingResponse.ok;
+      final BillingResultWrapper expectedBillingResult = BillingResultWrapper(
+          responseCode: responseCode, debugMessage: debugMessage);
+      stubPlatform.addResponse(
+        name: launchMethodName,
+        value: buildBillingResultMap(expectedBillingResult),
+      );
+      final SkuDetailsWrapper skuDetails = dummySkuDetails;
+      final String accountId = "hashedAccountId";
+
+      expect(
+          await billingClient.launchBillingFlow(
+              sku: skuDetails.sku,
+              accountId: accountId),
+          equals(expectedBillingResult));
+      Map<dynamic, dynamic> arguments =
+          stubPlatform.previousCallMatching(launchMethodName).arguments;
+      expect(arguments['sku'], equals(skuDetails.sku));
+      expect(arguments['accountId'], equals(accountId));
+      expect(arguments['oldSku'], isNull);
+      expect(arguments['replaceSkusProrationMode'], isNull);
     });
   });
 


### PR DESCRIPTION
## 무엇이 변경되었나요? 🎉

- 기존에 유저가 Non Consumable 아이템을 구독중일 떄, 새로운 Non Consumable 아이템으로 업그레이드, 다운그레이드 혹은 변경할 수 있도록 기능을 추가했어요.
	- 해당 PR 을 우리 내부적으로 리뷰를 본 후에, flutter/plugins Repository 에 PR 을 보낼 예정입니당

## 참고해야할 레퍼런스는 무엇인가요?

https://developer.android.com/google/play/billing/subscriptions#change

## 어떻게 변경되었나요?

- PurchaseParams 에 `oldSku`, `replaceProrationMode` 프로퍼티 추가 (Optional)
- `BillingClientWrapper` 에 안드로이드에서 제공하는 [ProrationMode](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.ProrationMode) 를 Dart Enum 으로 작성
- 안드로이드 네이티브 단에서
	- `oldSku`, `replaceProrationMode` 가 `null` 일 경우, 기존 Billing Flow 로 진행하고
	- `null` 이 아닐 경우, 구독 상품을 변경하도록 액션
- 추가된 `oldSku`, `replaceProrationMode` 에 대한 안드로이드 네이티브 부분 테스트 코드와, Dart 쪽 테스트 코드 작성

## 적용 스크린샷

![blimp_20201216_152607](https://user-images.githubusercontent.com/10934461/102325869-06cbe680-3fc7-11eb-8589-91d629e85dc4.png)
