### PR TITLE
feat(iOS): SKPaymentDiscountWrapper를 통한 Promotion Offer기능 추가

### DIFF
--- a/packages/in_app_purchase/ios/Classes/FIAObjectTranslator.h
+++ b/packages/in_app_purchase/ios/Classes/FIAObjectTranslator.h
@@ -25,6 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (SKMutablePayment *)getSKMutablePaymentFromMap:(NSDictionary *)map;
 
++ (SKPaymentDiscount *)getSKPaymentDiscountFromMap:(NSDictionary *)map
+    API_AVAILABLE(ios(12.2));
+
 + (NSDictionary *)getMapFromSKPaymentTransaction:(SKPaymentTransaction *)transaction;
 
 + (NSDictionary *)getMapFromNSError:(NSError *)error;

--- a/packages/in_app_purchase/ios/Classes/FIAObjectTranslator.h
+++ b/packages/in_app_purchase/ios/Classes/FIAObjectTranslator.h
@@ -28,6 +28,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (SKPaymentDiscount *)getSKPaymentDiscountFromMap:(NSDictionary *)map
     API_AVAILABLE(ios(12.2));
 
++ (NSDictionary *)getMapFromSKPaymentDiscount:(SKPaymentDiscount *)paymentDiscount
+    API_AVAILABLE(ios(12.2));
+
 + (NSDictionary *)getMapFromSKPaymentTransaction:(SKPaymentTransaction *)transaction;
 
 + (NSDictionary *)getMapFromNSError:(NSError *)error;

--- a/packages/in_app_purchase/ios/Classes/FIAObjectTranslator.m
+++ b/packages/in_app_purchase/ios/Classes/FIAObjectTranslator.m
@@ -127,7 +127,29 @@
   if (@available(iOS 8.3, *)) {
     payment.simulatesAskToBuyInSandbox = [map[@"simulatesAskToBuyInSandbox"] boolValue];
   }
+
+  if (@available(iOS 12.2, *)) {
+    payment.paymentDiscount = [FIAObjectTranslator getSKPaymentDiscountFromMap:map[@"paymentDiscount"]];
+  }
   return payment;
+}
+
++ (SKPaymentDiscount *) getSKPaymentDiscountFromMap:(NSDictionary *)map  API_AVAILABLE(ios(12.2)){
+    if(!map) {
+        return nil;
+    }
+    
+    
+    SKPaymentDiscount *paymentDiscount = [
+                                          [SKPaymentDiscount alloc]
+                                          initWithIdentifier:map[@"identifier"]
+                                          keyIdentifier:map[@"keyIdentifier"]
+                                          nonce:[[NSUUID alloc] initWithUUIDString:map[@"nonce"]]
+                                          signature:map[@"signature"]
+                                          timestamp:@([map[@"timestamp"] integerValue])
+                                          ];
+
+    return paymentDiscount;
 }
 
 + (NSDictionary *)getMapFromSKPaymentTransaction:(SKPaymentTransaction *)transaction {

--- a/packages/in_app_purchase/ios/Classes/FIAObjectTranslator.m
+++ b/packages/in_app_purchase/ios/Classes/FIAObjectTranslator.m
@@ -173,6 +173,20 @@
   return map;
 }
 
++ (NSDictionary *)getMapFromSKPaymentDiscount:(SKPaymentDiscount *)paymentDiscount  API_AVAILABLE(ios(12.2)){
+  if (!paymentDiscount) {
+    return nil;
+  }
+  NSMutableDictionary *map = [[NSMutableDictionary alloc] initWithDictionary:@{
+    @"identifier" : paymentDiscount.identifier,
+    @"keyIdentifier" : paymentDiscount.keyIdentifier,
+    @"nonce" : paymentDiscount.nonce.UUIDString,
+    @"signature" : paymentDiscount.signature,
+    @"timestamp" : paymentDiscount.timestamp,
+  }];
+  return map;
+}
+
 + (NSDictionary *)getMapFromNSError:(NSError *)error {
   if (!error) {
     return nil;

--- a/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
@@ -185,6 +185,10 @@
                                              : [simulatesAskToBuyInSandbox boolValue];
   }
 
+  if (@available(iOS 12.2, *)) {
+      payment.paymentDiscount = [FIAObjectTranslator getSKPaymentDiscountFromMap:paymentMap[@"paymentDiscount"]];
+  }
+
   if (![self.paymentQueueHandler addPayment:payment]) {
     result([FlutterError
         errorWithCode:@"storekit_duplicate_product_object"

--- a/packages/in_app_purchase/ios/Tests/TranslatorTest.m
+++ b/packages/in_app_purchase/ios/Tests/TranslatorTest.m
@@ -14,6 +14,7 @@
 @property(strong, nonatomic) NSMutableDictionary *productMap;
 @property(strong, nonatomic) NSDictionary *productResponseMap;
 @property(strong, nonatomic) NSDictionary *paymentMap;
+@property(strong, nonatomic) NSDictionary *paymentDiscountMap;
 @property(strong, nonatomic) NSDictionary *transactionMap;
 @property(strong, nonatomic) NSDictionary *errorMap;
 @property(strong, nonatomic) NSDictionary *localeMap;
@@ -50,6 +51,14 @@
 
   self.productResponseMap =
       @{@"products" : @[ self.productMap ], @"invalidProductIdentifiers" : @[]};
+
+  self.paymentDiscountMap = @{
+      @"identifier": @"123",
+      @"keyIdentifier": @"456",
+      @"nonce": @"00000000-0000-0000-0000-000000000000",
+      @"timestamp": @1234,
+      @"signature": @"123abcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefgh456",
+  };
   self.paymentMap = @{
     @"productIdentifier" : @"123",
     @"requestData" : @"abcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefgh",
@@ -57,6 +66,9 @@
     @"applicationUsername" : @"app user name",
     @"simulatesAskToBuyInSandbox" : @(NO)
   };
+  if (@available(iOS 12.2, *)) {
+    self.paymentMap[@"paymentDiscount"] = self.paymentDiscountMap;
+  }
   NSDictionary *originalTransactionMap = @{
     @"transactionIdentifier" : @"567",
     @"transactionState" : @(SKPaymentTransactionStatePurchasing),
@@ -120,6 +132,14 @@
   SKMutablePayment *payment = [FIAObjectTranslator getSKMutablePaymentFromMap:self.paymentMap];
   NSDictionary *map = [FIAObjectTranslator getMapFromSKPayment:payment];
   XCTAssertEqualObjects(map, self.paymentMap);
+}
+
+- (void)testPaymentDiscountToMap {
+  if (@available(iOS 12.2, *)) {
+    SKPaymentDiscount *paymentDiscount = [FIAObjectTranslator getSKPaymentDiscountFromMap:self.paymentDiscountMap];
+    NSDictionary *map = [FIAObjectTranslator getMapFromSKPaymentDiscount:paymentDiscount];
+    XCTAssertEqualObjects(map, self.paymentDiscountMap);
+  }
 }
 
 - (void)testPaymentTransactionToMap {

--- a/packages/in_app_purchase/lib/src/in_app_purchase/app_store_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/app_store_connection.dart
@@ -61,6 +61,7 @@ class AppStoreConnection implements InAppPurchaseConnection {
         quantity: 1,
         applicationUsername: purchaseParam.applicationUserName,
         simulatesAskToBuyInSandbox: purchaseParam.sandboxTesting,
+        paymentDiscount: purchaseParam.paymentDiscount,
         requestData: null));
     return true; // There's no error feedback from iOS here to return.
   }

--- a/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
@@ -7,6 +7,7 @@ import 'package:in_app_purchase/src/billing_client_wrappers/enum_converters.dart
 import 'package:in_app_purchase/src/billing_client_wrappers/purchase_wrapper.dart';
 import 'package:in_app_purchase/src/store_kit_wrappers/enum_converters.dart';
 import 'package:in_app_purchase/src/store_kit_wrappers/sk_payment_transaction_wrappers.dart';
+import 'package:in_app_purchase/src/store_kit_wrappers/sk_payment_queue_wrapper.dart';
 import './in_app_purchase_connection.dart';
 import './product_details.dart';
 
@@ -90,6 +91,7 @@ class PurchaseParam {
   PurchaseParam(
       {@required this.productDetails,
       this.applicationUserName,
+      this.paymentDiscount,
       this.sandboxTesting});
 
   /// The product to create payment for.
@@ -107,6 +109,9 @@ class PurchaseParam {
 
   /// The 'sandboxTesting' is only available on iOS, set it to `true` for testing in AppStore's sandbox environment. The default value is `false`.
   final bool sandboxTesting;
+
+  /// The 'paymentDiscount' is only available on iOS. Used to apply Promotion Offer on App Store. (Optional)
+  final SKPaymentDiscountWrapper paymentDiscount;
 }
 
 /// Represents the transaction details of a purchase.

--- a/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
@@ -251,6 +251,85 @@ class SKError {
 }
 
 /// Dart wrapper around StoreKit's
+/// [SKPaymentDiscount](https://developer.apple.com/documentation/storekit/skpaymentdiscount?language=objc).
+///
+/// Used to apply [Promotion Offer](https://developer.apple.com/app-store/subscriptions/#promotional-offers)
+/// from iOS 12.2 and later.
+///
+/// See [Setting Up Promotional Offers](https://developer.apple.com/documentation/storekit/in-app_purchase/subscriptions_and_offers/setting_up_promotional_offers?language=objc)
+@JsonSerializable(nullable: true)
+class SKPaymentDiscountWrapper {
+  /// Creates a new [SKPaymentDiscountWrapper] with the provided information.
+  SKPaymentDiscountWrapper(
+      {@required this.identifier,
+      @required this.keyIdentifier,
+      @required this.nonce,
+      @required this.signature,
+      @required this.timestamp});
+
+  /// Constructs an instance of this from a key value map of data.
+  ///
+  /// The map needs to have named string keys with values matching the names and
+  /// types of all of the members on this class. The `map` parameter must not be
+  /// null.
+  factory SKPaymentDiscountWrapper.fromJson(Map map) {
+    return _$SKPaymentDiscountWrapperFromJson(map);
+  }
+
+  /// Creates a Map object describes the object.
+  Map<String, dynamic> toMap() {
+    return {
+      'identifier': identifier,
+      'keyIdentifier': keyIdentifier,
+      'nonce': nonce,
+      'signature': signature,
+      'timestamp': timestamp,
+    };
+  }
+
+  /// The id for the promotion offer discount
+  final String identifier;
+
+  /// The id to identify private key used when created the [signature]
+  final String keyIdentifier;
+
+  /// The unique id generated from server when created the [signature].
+  final String nonce;
+
+  /// The unique string for the App Store to validate the promotion offer.
+  ///
+  /// See [Generating a Signature for Promotional Offers](https://developer.apple.com/documentation/storekit/in-app_purchase/subscriptions_and_offers/generating_a_signature_for_promotional_offers?language=objc)
+  /// and [Create a Signature](https://developer.apple.com/documentation/storekit/in-app_purchase/subscriptions_and_offers/implementing_promotional_offers_in_your_app?language=objc#3150981)
+  final String signature;
+
+  /// The time when [signature] is created. UNIX epoch time formatted milliseconds.
+  final int timestamp;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) {
+      return true;
+    }
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    final SKPaymentDiscountWrapper typedOther = other;
+    return typedOther.identifier == identifier &&
+        typedOther.keyIdentifier == keyIdentifier &&
+        typedOther.nonce == nonce &&
+        typedOther.timestamp == timestamp &&
+        typedOther.signature == signature;
+  }
+
+  @override
+  int get hashCode => hashValues(this.identifier, this.keyIdentifier,
+      this.nonce, this.timestamp, this.signature);
+
+  @override
+  String toString() => _$SKPaymentDiscountWrapperToJson(this).toString();
+}
+
+/// Dart wrapper around StoreKit's
 /// [SKPayment](https://developer.apple.com/documentation/storekit/skpayment?language=objc).
 ///
 /// Used as the parameter to initiate a payment. In general, a developer should
@@ -265,6 +344,7 @@ class SKPaymentWrapper {
       this.applicationUsername,
       this.requestData,
       this.quantity = 1,
+      this.paymentDiscount,
       this.simulatesAskToBuyInSandbox = false});
 
   /// Constructs an instance of this from a key value map of data.
@@ -284,7 +364,8 @@ class SKPaymentWrapper {
       'applicationUsername': applicationUsername,
       'requestData': requestData,
       'quantity': quantity,
-      'simulatesAskToBuyInSandbox': simulatesAskToBuyInSandbox
+      'simulatesAskToBuyInSandbox': simulatesAskToBuyInSandbox,
+      'paymentDiscount': paymentDiscount?.toMap()
     };
   }
 
@@ -324,6 +405,13 @@ class SKPaymentWrapper {
   /// testing.
   final bool simulatesAskToBuyInSandbox;
 
+  /// The details of a promotional offer discount that you want to apply to the payment.
+  ///
+  /// See [paymentDiscount](https://developer.apple.com/documentation/storekit/skpayment/3043526-paymentdiscount?language=objc))
+  /// and [SKPaymentDiscount](https://developer.apple.com/documentation/storekit/skpaymentdiscount?language=objc)
+  /// for more details.
+  final SKPaymentDiscountWrapper paymentDiscount;
+
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) {
@@ -337,6 +425,7 @@ class SKPaymentWrapper {
         typedOther.applicationUsername == applicationUsername &&
         typedOther.quantity == quantity &&
         typedOther.simulatesAskToBuyInSandbox == simulatesAskToBuyInSandbox &&
+        typedOther.paymentDiscount == paymentDiscount &&
         typedOther.requestData == requestData;
   }
 
@@ -346,6 +435,7 @@ class SKPaymentWrapper {
       this.applicationUsername,
       this.quantity,
       this.simulatesAskToBuyInSandbox,
+      this.paymentDiscount,
       this.requestData);
 
   @override

--- a/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.g.dart
+++ b/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.g.dart
@@ -22,18 +22,42 @@ Map<String, dynamic> _$SKErrorToJson(SKError instance) => <String, dynamic>{
       'userInfo': instance.userInfo,
     };
 
+SKPaymentDiscountWrapper _$SKPaymentDiscountWrapperFromJson(Map json) {
+  return SKPaymentDiscountWrapper(
+    identifier: json['identifier'] as String,
+    keyIdentifier: json['keyIdentifier'] as String,
+    nonce: json['nonce'] as String,
+    signature: json['signature'] as String,
+    timestamp: json['timestamp'] as int,
+  );
+}
+
+Map<String, dynamic> _$SKPaymentDiscountWrapperToJson(
+        SKPaymentDiscountWrapper instance) =>
+    <String, dynamic>{
+      'identifier': instance.identifier,
+      'keyIdentifier': instance.keyIdentifier,
+      'nonce': instance.nonce,
+      'signature': instance.signature,
+      'timestamp': instance.timestamp,
+    };
+
 SKPaymentWrapper _$SKPaymentWrapperFromJson(Map json) {
   return SKPaymentWrapper(
     productIdentifier: json['productIdentifier'] as String,
     applicationUsername: json['applicationUsername'] as String,
     requestData: json['requestData'] as String,
     quantity: json['quantity'] as int,
+    paymentDiscount: json['paymentDiscount'] == null
+        ? null
+        : SKPaymentDiscountWrapper.fromJson(json['paymentDiscount'] as Map),
     simulatesAskToBuyInSandbox: json['simulatesAskToBuyInSandbox'] as bool,
   );
 }
 
 Map<String, dynamic> _$SKPaymentWrapperToJson(SKPaymentWrapper instance) =>
     <String, dynamic>{
+      'paymentDiscount': instance.paymentDiscount,
       'productIdentifier': instance.productIdentifier,
       'applicationUsername': instance.applicationUsername,
       'requestData': instance.requestData,

--- a/packages/in_app_purchase/test/store_kit_wrappers/sk_product_test.dart
+++ b/packages/in_app_purchase/test/store_kit_wrappers/sk_product_test.dart
@@ -115,6 +115,11 @@ void main() {
       expect(payment, equals(dummyPayment));
     });
 
+    test('Should construct correct SKPaymentDiscountWrapper from json', () {
+      SKPaymentDiscountWrapper paymentDiscount = SKPaymentDiscountWrapper.fromJson(dummyPaymentDiscount.toMap());
+      expect(paymentDiscount, equals(dummyPaymentDiscount));
+    });
+
     test('Should construct correct SKError from json', () {
       SKError error = SKError.fromJson(buildErrorMap(dummyError));
       expect(error, equals(dummyError));
@@ -152,6 +157,10 @@ void main() {
 
       expect(map['simulatesAskToBuyInSandbox'],
           dummyPayment.simulatesAskToBuyInSandbox);
+
+      expect(map['paymentDiscount'],
+          dummyPayment.paymentDiscount.toMap());
     });
+
   });
 }

--- a/packages/in_app_purchase/test/store_kit_wrappers/sk_test_stub_objects.dart
+++ b/packages/in_app_purchase/test/store_kit_wrappers/sk_test_stub_objects.dart
@@ -9,9 +9,16 @@ final dummyPayment = SKPaymentWrapper(
     applicationUsername: 'app-user-name',
     requestData: 'fake-data-utf8',
     quantity: 2,
+    paymentDiscount: dummyPaymentDiscount,
     simulatesAskToBuyInSandbox: true);
 final SKError dummyError =
     SKError(code: 111, domain: 'dummy-domain', userInfo: {'key': 'value'});
+final SKPaymentDiscountWrapper dummyPaymentDiscount = SKPaymentDiscountWrapper(
+    identifier: 'prod-id',
+    keyIdentifier: 'fake-key',
+    nonce: 'fake-uuid',
+    signature: 'fake-data-utf8',
+    timestamp: 1234);
 
 final SKPaymentTransactionWrapper dummyOriginalTransaction =
     SKPaymentTransactionWrapper(


### PR DESCRIPTION
## 무엇이 변경되었나요? 🎉

- StoreKit에 있는 [`SKPaymentDiscount`](https://developer.apple.com/documentation/storekit/skpayment)의 Dart Wrapper, `SKPaymentDiscountWrapper` 가 추가되었습니다.
- Dart: `SKPaymentWrapper`와 `PurchaseParam`에 `paymentDiscount` 파라미터가 추가되었습니다. iOS의 [`SKPayment.paymentDiscount`](https://developer.apple.com/documentation/storekit/skpayment/3043526-paymentdiscount)와 동일한 역할을 합니다.
- iOS: `.addPayment` 함수에서 `SKPayment` 객체를 만들때, Dart가 넘겨준 `paymentDiscount` 정보를 추가하도록 변경했습니다.

## 추가로 알아야할 내용

몇 가지 빠진 부분이 있습니다

1. README.md 에 사용법 작성하기
2. `applicationName`, `appBundleIdentifier` 등 `signature`를 만들때 사용할 수 있는 추가 키값들을 `SKPaymentDiscountWrapper`에 추가하기