### PR TITLE
fix: iOS 에서 SKPaymentDiscount 가 없을 경우에 플러그인이 강제중지 되는 문제 수정

### DIFF
--- a/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
@@ -186,7 +186,11 @@
   }
 
   if (@available(iOS 12.2, *)) {
-      payment.paymentDiscount = [FIAObjectTranslator getSKPaymentDiscountFromMap:paymentMap[@"paymentDiscount"]];
+      NSDictionary *paymentDiscount = [paymentMap objectForKey:@"paymentDiscount"];
+      
+      if (paymentDiscount != (id)[NSNull null]) {
+          payment.paymentDiscount = [FIAObjectTranslator getSKPaymentDiscountFromMap:paymentDiscount];
+      }
   }
 
   if (![self.paymentQueueHandler addPayment:payment]) {


### PR DESCRIPTION
## 무엇이 변경되었나요? 🎉

- SKPaymentDiscount 가 null 로 들어올 경우, 플러그인이 강제중지 되는 문제를 수정했습니다.