### PR TITLE
chore: 구글 플레이스토어 결제 라이브러리 버전 업데이트 (2 → 3)

### DIFF
--- a/packages/in_app_purchase/android/build.gradle
+++ b/packages/in_app_purchase/android/build.gradle
@@ -35,7 +35,7 @@ android {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.0.0'
-    implementation 'com.android.billingclient:billing:2.0.3'
+    implementation 'com.android.billingclient:billing:3.0.2'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.17.0'
     androidTestImplementation 'androidx.test:runner:1.1.1'

--- a/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/MethodCallHandlerImpl.java
+++ b/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/MethodCallHandlerImpl.java
@@ -123,7 +123,7 @@ class MethodCallHandlerImpl
             (String) call.argument("sku"),
             (String) call.argument("accountId"),
             (String) call.argument("oldSku"),
-            (String) call.argument("purchaseToken"),
+            (String) call.argument("oldPurchaseToken"),
             (Integer) call.argument("replaceSkusProrationMode"), result);
         break;
       case InAppPurchasePlugin.MethodNames.QUERY_PURCHASES:

--- a/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/MethodCallHandlerImpl.java
+++ b/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/MethodCallHandlerImpl.java
@@ -123,6 +123,7 @@ class MethodCallHandlerImpl
             (String) call.argument("sku"),
             (String) call.argument("accountId"),
             (String) call.argument("oldSku"),
+            (String) call.argument("purchaseToken"),
             (Integer) call.argument("replaceSkusProrationMode"), result);
         break;
       case InAppPurchasePlugin.MethodNames.QUERY_PURCHASES:
@@ -134,7 +135,6 @@ class MethodCallHandlerImpl
       case InAppPurchasePlugin.MethodNames.CONSUME_PURCHASE_ASYNC:
         consumeAsync(
             (String) call.argument("purchaseToken"),
-            (String) call.argument("developerPayload"),
             result);
         break;
       case InAppPurchasePlugin.MethodNames.ACKNOWLEDGE_PURCHASE:
@@ -195,6 +195,7 @@ class MethodCallHandlerImpl
       String sku,
       @Nullable String accountId,
       @Nullable String oldSku,
+      @Nullable String oldPurchaseToken,
       @Nullable Integer replaceSkusProrationMode,
       MethodChannel.Result result) {
     if (billingClientError(result)) {
@@ -223,11 +224,11 @@ class MethodCallHandlerImpl
     BillingFlowParams.Builder paramsBuilder =
         BillingFlowParams.newBuilder();
     if (accountId != null && !accountId.isEmpty()) {
-      paramsBuilder.setAccountId(accountId);
+      paramsBuilder.setObfuscatedAccountId(accountId);
     }
-    if (oldSku != null && replaceSkusProrationMode != null) {
+    if (oldSku != null && replaceSkusProrationMode != null && oldPurchaseToken != null) {
       paramsBuilder
-        .setOldSku(oldSku)
+        .setOldSku(oldSku, oldPurchaseToken)
         .setReplaceSkusProrationMode(replaceSkusProrationMode)
         .setSkuDetails(skuDetails);
     } else {
@@ -240,7 +241,7 @@ class MethodCallHandlerImpl
   }
 
   private void consumeAsync(
-      String purchaseToken, String developerPayload, final MethodChannel.Result result) {
+      String purchaseToken, final MethodChannel.Result result) {
     if (billingClientError(result)) {
       return;
     }
@@ -254,10 +255,6 @@ class MethodCallHandlerImpl
         };
     ConsumeParams.Builder paramsBuilder =
         ConsumeParams.newBuilder().setPurchaseToken(purchaseToken);
-
-    if (developerPayload != null) {
-      paramsBuilder.setDeveloperPayload(developerPayload);
-    }
     ConsumeParams params = paramsBuilder.build();
 
     billingClient.consumeAsync(params, listener);
@@ -331,7 +328,6 @@ class MethodCallHandlerImpl
     }
     AcknowledgePurchaseParams params =
         AcknowledgePurchaseParams.newBuilder()
-            .setDeveloperPayload(developerPayload)
             .setPurchaseToken(purchaseToken)
             .build();
     billingClient.acknowledgePurchase(

--- a/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/Translator.java
+++ b/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/Translator.java
@@ -31,7 +31,6 @@ import java.util.List;
     info.put("priceCurrencyCode", detail.getPriceCurrencyCode());
     info.put("sku", detail.getSku());
     info.put("type", detail.getType());
-    info.put("isRewarded", detail.isRewarded());
     info.put("subscriptionPeriod", detail.getSubscriptionPeriod());
     info.put("originalPrice", detail.getOriginalPrice());
     info.put("originalPriceAmountMicros", detail.getOriginalPriceAmountMicros());

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -182,6 +182,7 @@ class BillingClient {
   Future<BillingResultWrapper> launchBillingFlow(
       {@required String sku,
       String oldSku,
+      String purchaseToken,
       String accountId,
       ProrationMode replaceSkusProrationMode}) async {
     assert(sku != null);
@@ -189,6 +190,7 @@ class BillingClient {
       'sku': sku,
       'accountId': accountId,
       'oldSku': oldSku,
+      'purchaseToken': purchaseToken,
       'replaceSkusProrationMode':
           ProrationModeConverter().toJson(replaceSkusProrationMode),
     };

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -182,7 +182,7 @@ class BillingClient {
   Future<BillingResultWrapper> launchBillingFlow(
       {@required String sku,
       String oldSku,
-      String purchaseToken,
+      String oldPurchaseToken,
       String accountId,
       ProrationMode replaceSkusProrationMode}) async {
     assert(sku != null);
@@ -190,7 +190,7 @@ class BillingClient {
       'sku': sku,
       'accountId': accountId,
       'oldSku': oldSku,
-      'purchaseToken': purchaseToken,
+      'oldPurchaseToken': oldPurchaseToken,
       'replaceSkusProrationMode':
           ProrationModeConverter().toJson(replaceSkusProrationMode),
     };

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/sku_details_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/sku_details_wrapper.dart
@@ -35,7 +35,6 @@ class SkuDetailsWrapper {
     @required this.subscriptionPeriod,
     @required this.title,
     @required this.type,
-    @required this.isRewarded,
     @required this.originalPrice,
     @required this.originalPriceAmountMicros,
   });
@@ -87,9 +86,6 @@ class SkuDetailsWrapper {
   /// The [SkuType] of the product.
   final SkuType type;
 
-  /// False if the product is paid.
-  final bool isRewarded;
-
   /// The original price that the user purchased this product for.
   final String originalPrice;
 
@@ -116,7 +112,6 @@ class SkuDetailsWrapper {
         typedOther.subscriptionPeriod == subscriptionPeriod &&
         typedOther.title == title &&
         typedOther.type == type &&
-        typedOther.isRewarded == isRewarded &&
         typedOther.originalPrice == originalPrice &&
         typedOther.originalPriceAmountMicros == originalPriceAmountMicros;
   }
@@ -136,7 +131,6 @@ class SkuDetailsWrapper {
         subscriptionPeriod.hashCode,
         title.hashCode,
         type.hashCode,
-        isRewarded.hashCode,
         originalPrice,
         originalPriceAmountMicros);
   }

--- a/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
@@ -63,6 +63,7 @@ class GooglePlayConnection
             sku: purchaseParam.productDetails.id,
             accountId: purchaseParam.applicationUserName,
             oldSku: purchaseParam.oldSku,
+            purchaseToken: purchaseParam.purchaseToken,
             replaceSkusProrationMode: purchaseParam.replaceProrationMode);
     return billingResultWrapper.responseCode == BillingResponse.ok;
   }

--- a/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
@@ -63,7 +63,7 @@ class GooglePlayConnection
             sku: purchaseParam.productDetails.id,
             accountId: purchaseParam.applicationUserName,
             oldSku: purchaseParam.oldSku,
-            purchaseToken: purchaseParam.purchaseToken,
+            oldPurchaseToken: purchaseParam.oldPurchaseToken,
             replaceSkusProrationMode: purchaseParam.replaceProrationMode);
     return billingResultWrapper.responseCode == BillingResponse.ok;
   }

--- a/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
@@ -94,6 +94,7 @@ class PurchaseParam {
       this.paymentDiscount,
       this.oldSku,
       this.replaceProrationMode,
+      this.purchaseToken,
       this.sandboxTesting});
   /// The product to create payment for.
   ///
@@ -117,6 +118,8 @@ class PurchaseParam {
   /// In iOS, this property is not used.
   /// If you set up [productDetails] as you want to change, it will proceed automatically.
   final ProrationMode replaceProrationMode;
+
+  final String purchaseToken;
 
   /// An opaque id for the user's account that's unique to your app. (Optional)
   ///

--- a/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
@@ -94,7 +94,7 @@ class PurchaseParam {
       this.paymentDiscount,
       this.oldSku,
       this.replaceProrationMode,
-      this.purchaseToken,
+      this.oldPurchaseToken,
       this.sandboxTesting});
   /// The product to create payment for.
   ///
@@ -119,7 +119,7 @@ class PurchaseParam {
   /// If you set up [productDetails] as you want to change, it will proceed automatically.
   final ProrationMode replaceProrationMode;
 
-  final String purchaseToken;
+  final String oldPurchaseToken;
 
   /// An opaque id for the user's account that's unique to your app. (Optional)
   ///

--- a/packages/in_app_purchase/test/billing_client_wrappers/sku_details_wrapper_test.dart
+++ b/packages/in_app_purchase/test/billing_client_wrappers/sku_details_wrapper_test.dart
@@ -21,7 +21,6 @@ final SkuDetailsWrapper dummySkuDetails = SkuDetailsWrapper(
   subscriptionPeriod: 'subscriptionPeriod',
   title: 'title',
   type: SkuType.inapp,
-  isRewarded: true,
   originalPrice: 'originalPrice',
   originalPriceAmountMicros: 1000,
 );
@@ -117,7 +116,6 @@ Map<String, dynamic> buildSkuMap(SkuDetailsWrapper original) {
     'subscriptionPeriod': original.subscriptionPeriod,
     'title': original.title,
     'type': original.type.toString().substring(8),
-    'isRewarded': original.isRewarded,
     'originalPrice': original.originalPrice,
     'originalPriceAmountMicros': original.originalPriceAmountMicros,
   };


### PR DESCRIPTION
## 무엇이 변경되었나요? 🎉

- 구글 플레이스토어 결제 라이브러리 버전을 2 → 3 으로 업데이트 했어요.
- 버전 3으로 올라감에 따라, 변경된 API 를 적용하고, 사라진 Property 는 삭제했습니다.

## 업데이트를 한 이유는 무엇인가요?

Non consumable 아이템에 대해서 변경을 하기 위해서는 `setProrationMode`, `setOldSku` 를 사용해야 해요.
구버전은 현재의 구글 플레이스토어에 지원이 중단된 API 를 활용하다 보니, accountId 를 내부적으로 자체생성해서 사용하다보니 앱의 데이터 삭제 / 재설치가 이루어지면 accountId 가 달라져서 아이템 변경이 이루어지지 않고 중복 결제가 발생하게 돼요.

버전 3 부터 setOldSku 에 purchaseToken 이 직접적으로 들어가면서, 위와 같은 현상이 없어졌어요.
그래서 변경하게 됐습니다.